### PR TITLE
Adding the gen_match study codes

### DIFF
--- a/NanoCORE/DiJetSelections.cc
+++ b/NanoCORE/DiJetSelections.cc
@@ -43,3 +43,50 @@ DiJets DiJetPreselection(Jets &jets) {
     }
     return dijets;    
 }
+
+GenJets getGenJets() {
+    GenJets Genjets;
+    for (unsigned int ijet = 0; ijet < nt.nGenJet(); ijet++) {
+        GenJet cand_genjet = GenJet(ijet);
+        if ( !(abs(cand_genjet.eta()) < 2.4) ) continue;
+        if ( !(cand_genjet.pt() > 25) ) continue;
+        Genjets.push_back(cand_genjet);
+    }
+    return Genjets;
+}
+
+GenDiJets GenDiJetPreselection(GenJets &Genjets) {
+    GenDiJets Gendijets;   
+    if (Genjets.size() > 1) {
+        GenDiJet Gendijet = GenDiJet(Genjets[0], Genjets[1]);
+        Gendijets.push_back(Gendijet);
+    }
+    return Gendijets;    
+}
+
+FatJets getFatJets(Photons photons) {
+    FatJets Fatjets;
+    FatJet lead_FatJet;
+    float lead_Hbb_score=0;
+    if (nt.nFatJet()==0) return Fatjets;
+    for (unsigned int ijet = 0; ijet < nt.nFatJet(); ijet++) {
+        FatJet cand_fatjet = FatJet(ijet);
+        if ( !(abs(cand_fatjet.eta()) < 2.5) ) continue;
+        if ( !(cand_fatjet.pt() > 200) ) continue;
+        if ( !(cand_fatjet.mass() > 40) ) continue;
+        if ( !(cand_fatjet.jetId() < 1) ) continue;
+        bool clean_with_photon = true;
+        for (unsigned int iphoton = 0; iphoton < photons.size(); iphoton++){
+            if (cand_fatjet.p4().DeltaR(photons.at(iphoton).p4())<0.8) clean_with_photon = false;
+        }
+
+        if (clean_with_photon == false) continue;
+        if (cand_fatjet.Hbb_score()>lead_Hbb_score) {
+            lead_Hbb_score = cand_fatjet.Hbb_score();
+            lead_FatJet = cand_fatjet;
+        }
+    }
+    //Fatjets are naturally sorted by pt in NanoAOD
+    if (lead_Hbb_score>0) Fatjets.push_back(lead_FatJet);
+    return Fatjets;
+}

--- a/NanoCORE/DiJetSelections.h
+++ b/NanoCORE/DiJetSelections.h
@@ -132,8 +132,66 @@ struct Jet {
     float btagSF_deepjet_shape_down_cferr2_ = 1.0;
 };
 
+struct GenJet {
+    GenJet(unsigned int idx = 0) : idx_(idx) {
+        pt_ = nt.GenJet_pt()[idx_];
+        mass_ = nt.GenJet_mass()[idx_];
+        eta_ = nt.GenJet_eta()[idx_];
+        phi_ = nt.GenJet_phi()[idx_];
+        p4_.SetPtEtaPhiM(pt_, nt.GenJet_eta()[idx_], nt.GenJet_phi()[idx_], nt.GenJet_mass()[idx_]);
+    }
+    TLorentzVector p4() { return p4_; }
+    unsigned int idx() { return idx_; }
+    float pt() { return pt_; }
+    float mass() { return mass_; }
+    float eta() { return eta_; }
+    float phi() { return phi_; }
+
+  private:
+    float pt_ = 0.;
+    float eta_ = 0.;
+    float mass_ = 0.;
+    float phi_ = 0.;
+    TLorentzVector p4_;
+    unsigned int idx_;
+};
+
+struct FatJet {
+    FatJet(unsigned int idx = 0) : idx_(idx) {
+        pt_ = nt.FatJet_pt()[idx_];
+        mass_ = nt.FatJet_msoftdrop()[idx_];
+        eta_ = nt.FatJet_eta()[idx_];
+        phi_ = nt.FatJet_phi()[idx_];
+        p4_.SetPtEtaPhiM(pt_, nt.FatJet_eta()[idx_], nt.FatJet_phi()[idx_], nt.FatJet_msoftdrop()[idx_]);
+        jetId_ = nt.Jet_jetId()[idx_];
+        Hbb_score_ = nt.FatJet_particleNetMD_Xbb()[idx_]/(nt.FatJet_particleNetMD_Xbb()[idx_]+nt.FatJet_particleNetMD_QCD()[idx_]);
+    }
+    TLorentzVector p4() { return p4_; }
+    unsigned int idx() { return idx_; }
+    float pt() { return pt_; }
+    float mass() { return mass_; }
+    float eta() { return eta_; }
+    float phi() { return phi_; }
+    int jetId() { return jetId_; }
+    float Hbb_score() {return Hbb_score_;}
+
+  private:
+    float pt_ = 0.;
+    float eta_ = 0.;
+    float mass_ = 0.;
+    float phi_ = 0.;
+    TLorentzVector p4_;
+    unsigned int idx_;
+    int jetId_ = 0;
+    float Hbb_score_ = 0;
+};
+
 vector<Jet> getJets(Photons photons, const int JESUnc, const int JERUnc);
 typedef std::vector<Jet> Jets;
+vector<GenJet> getGenJets();
+typedef std::vector<GenJet> GenJets;
+vector<FatJet> getFatJets(Photons photons);
+typedef std::vector<FatJet> FatJets;
 
 struct DiJet{
     Jet leadJet;
@@ -158,11 +216,35 @@ struct DiJet{
 
 typedef std::vector<DiJet> DiJets;
 
+struct GenDiJet{
+    GenJet leadGenJet;
+    GenJet subleadGenJet;
+    TLorentzVector p4;
+    float dR;
+    GenDiJet(GenJet p1, GenJet p2)
+    {
+        if (p1.pt() > p2.pt()) {
+            leadGenJet = p1;
+            subleadGenJet = p2;
+        } else {
+            leadGenJet = p2;
+            subleadGenJet = p1;
+        }
+        TLorentzVector leadGenJetp4 = leadGenJet.p4();
+        TLorentzVector subleadGenJetp4 = subleadGenJet.p4();
+        p4 = leadGenJetp4 + subleadGenJetp4;
+        dR = leadGenJetp4.DeltaR(subleadGenJetp4);
+    }
+};
+
+typedef std::vector<GenDiJet> GenDiJets;
+
 inline bool sortBybscore(Jet &p1, Jet &p2)
 {
         return p1.btagDeepFlavB() > p2.btagDeepFlavB();    
 }
 
 DiJets DiJetPreselection(Jets &jets); 
+GenDiJets GenDiJetPreselection(GenJets &Genjets); 
 
 #endif

--- a/NanoCORE/DiJetSelections.h
+++ b/NanoCORE/DiJetSelections.h
@@ -165,8 +165,30 @@ struct FatJet {
         p4_.SetPtEtaPhiM(pt_, nt.FatJet_eta()[idx_], nt.FatJet_phi()[idx_], nt.FatJet_msoftdrop()[idx_]);
         jetId_ = nt.Jet_jetId()[idx_];
         Hbb_score_ = nt.FatJet_particleNetMD_Xbb()[idx_]/(nt.FatJet_particleNetMD_Xbb()[idx_]+nt.FatJet_particleNetMD_QCD()[idx_]);
+        subJetIdx1_ = nt.FatJet_subJetIdx1()[idx_];
+        subJetIdx2_ = nt.FatJet_subJetIdx2()[idx_];
+        nSubJet_ = nt.nSubJet();
+        if (subJetIdx1_!=-1 && subJetIdx2_!=-1)
+        {
+            if (nt.SubJet_btagDeepB()[subJetIdx1_]>nt.SubJet_btagDeepB()[subJetIdx2_])
+            {
+                SubJet1_p4_.SetPtEtaPhiM(nt.SubJet_pt()[subJetIdx1_], nt.SubJet_eta()[subJetIdx1_], nt.SubJet_phi()[subJetIdx1_], nt.SubJet_mass()[subJetIdx1_]);
+                SubJet2_p4_.SetPtEtaPhiM(nt.SubJet_pt()[subJetIdx2_], nt.SubJet_eta()[subJetIdx2_], nt.SubJet_phi()[subJetIdx2_], nt.SubJet_mass()[subJetIdx2_]);
+                subjet1_bscore_ = nt.SubJet_btagDeepB()[subJetIdx1_];
+                subjet2_bscore_ = nt.SubJet_btagDeepB()[subJetIdx2_];
+            }
+            if (nt.SubJet_btagDeepB()[subJetIdx2_]>nt.SubJet_btagDeepB()[subJetIdx1_])
+            {
+                SubJet2_p4_.SetPtEtaPhiM(nt.SubJet_pt()[subJetIdx1_], nt.SubJet_eta()[subJetIdx1_], nt.SubJet_phi()[subJetIdx1_], nt.SubJet_mass()[subJetIdx1_]);
+                SubJet1_p4_.SetPtEtaPhiM(nt.SubJet_pt()[subJetIdx2_], nt.SubJet_eta()[subJetIdx2_], nt.SubJet_phi()[subJetIdx2_], nt.SubJet_mass()[subJetIdx2_]);
+                subjet1_bscore_ = nt.SubJet_btagDeepB()[subJetIdx2_];
+                subjet2_bscore_ = nt.SubJet_btagDeepB()[subJetIdx1_];
+            }
+        }
     }
     TLorentzVector p4() { return p4_; }
+    TLorentzVector SubJet1_p4() { return SubJet1_p4_; }
+    TLorentzVector SubJet2_p4() { return SubJet2_p4_; }
     unsigned int idx() { return idx_; }
     float pt() { return pt_; }
     float mass() { return mass_; }
@@ -174,6 +196,11 @@ struct FatJet {
     float phi() { return phi_; }
     int jetId() { return jetId_; }
     float Hbb_score() {return Hbb_score_;}
+    float subjet1_bscore() {return subjet1_bscore_;}
+    float subjet2_bscore() {return subjet2_bscore_;}
+    int subJetIdx1() {return subJetIdx1_;}
+    int subJetIdx2() {return subJetIdx2_;}
+    int nSubJet() {return nSubJet_;}
 
   private:
     float pt_ = 0.;
@@ -181,9 +208,16 @@ struct FatJet {
     float mass_ = 0.;
     float phi_ = 0.;
     TLorentzVector p4_;
+    TLorentzVector SubJet1_p4_;
+    TLorentzVector SubJet2_p4_;
     unsigned int idx_;
     int jetId_ = 0;
     float Hbb_score_ = 0;
+    int subJetIdx1_ = 0;
+    int subJetIdx2_ = 0;
+    int nSubJet_ = 0;
+    float subjet1_bscore_ = 0;
+    float subjet2_bscore_ = 0;
 };
 
 vector<Jet> getJets(Photons photons, const int JESUnc, const int JERUnc);

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -941,32 +941,32 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
         GenParts genparts = getGenParts();
         vector<TLorentzVector> gen_child_xyh, gen_child_ygg, gen_child_hbb;
         for (int igenpart=0; igenpart<genparts.size(); igenpart++)
-          {
-            if (genparts[igenpart].isxyh()) {
-              GenX = genparts[igenpart].mother_p4(); 
-              gen_child_xyh.push_back(genparts[igenpart].p4());
-              GenX_pt = GenX.Pt();
-              GenX_eta = GenX.Eta();
-              GenX_phi = GenX.Phi();
-              GenX_mass = GenX.M();
-            }
-            if (genparts[igenpart].isygg()) {
-              GenY = genparts[igenpart].mother_p4(); 
-              gen_child_ygg.push_back(genparts[igenpart].p4());
-              GenY_pt = GenY.Pt();
-              GenY_eta = GenY.Eta();
-              GenY_phi = GenY.Phi();
-              GenY_mass = GenY.M();
-            }
-            if (genparts[igenpart].ishbb()) {
-              GenHiggs = genparts[igenpart].mother_p4();
-              gen_child_hbb.push_back(genparts[igenpart].p4());
-              GenHiggs_pt = GenHiggs.Pt();
-              GenHiggs_eta = GenHiggs.Eta();
-              GenHiggs_phi = GenHiggs.Phi();
-              GenHiggs_mass = GenHiggs.M();
-            }
+        {
+          if (genparts[igenpart].isxyh()) {
+            GenX = genparts[igenpart].mother_p4(); 
+            gen_child_xyh.push_back(genparts[igenpart].p4());
+            GenX_pt = GenX.Pt();
+            GenX_eta = GenX.Eta();
+            GenX_phi = GenX.Phi();
+            GenX_mass = GenX.M();
           }
+          if (genparts[igenpart].isygg()) {
+            GenY = genparts[igenpart].mother_p4(); 
+            gen_child_ygg.push_back(genparts[igenpart].p4());
+            GenY_pt = GenY.Pt();
+            GenY_eta = GenY.Eta();
+            GenY_phi = GenY.Phi();
+            GenY_mass = GenY.M();
+          }
+          if (genparts[igenpart].ishbb()) {
+            GenHiggs = genparts[igenpart].mother_p4();
+            gen_child_hbb.push_back(genparts[igenpart].p4());
+            GenHiggs_pt = GenHiggs.Pt();
+            GenHiggs_eta = GenHiggs.Eta();
+            GenHiggs_phi = GenHiggs.Phi();
+            GenHiggs_mass = GenHiggs.M();
+          }
+        }
         if (!abs(GenX_pt+999)<0.0001){
           GenX_dR = gen_child_xyh[0].DeltaR(gen_child_xyh[1]);
         }
@@ -985,6 +985,9 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
           GenBFromHiggs_2_eta = gen_child_hbb[1].Eta();
           GenBFromHiggs_2_phi = gen_child_hbb[1].Phi();
           GenBFromHiggs_2_mass = gen_child_hbb[1].M();
+
+// The following code is for the study of gen jet match to gen particle, which is not needed to run every time in the analysis. 
+// Remove the comment and run these lines when cross check that if the gen_child information is correct w.r.t. the gen_Jet
 /*
         // use gen part as seed, which gen jet is matched to GenBFromHiggs1 and 2?
           int Genjet_match_to_GenB1=-1,Genjet_match_to_GenB2=-1;
@@ -1017,7 +1020,10 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
             }
           } 
 */
-//          if (GenB1_Genjet_match && GenB2_Genjet_match) cout<<mindR2<<Genjet_match_to_GenB1<<Genjet_match_to_GenB2<<endl;
+
+// The following code is for the study of reco dijet matched to gen particle, which is not needed to run every time in the analysis, commented out to save time. 
+// Remove the comment and run these lines to study if the 2 gen particles can find their reco matches. 
+// This study tells our selected dijet pair is 2 match or 1 match or 0 match w.r.t. gen particle, which means if our output dijets are selecting the correct jets from Higgs
 /*
           // use gen part as seed, which reco dijet is matched to GenBFromHiggs1 and 2?
           int reco_match_to_GenB1=-1,reco_match_to_GenB2=-1;
@@ -1036,11 +1042,9 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
               }
             }
           }
-//          for (int ijet=0; ijet<jets.size(); ijet++)
           for (int ijet=0; ijet<2; ijet++)
           {
             float dR2;
-//            dR2 = jets[ijet].p4().DeltaR(gen_child_hbb[1]);
             if(ijet==0) dR2 = selectedDiJet.leadJet.p4().DeltaR(gen_child_hbb[1]);
             else if(ijet==1) dR2 = selectedDiJet.subleadJet.p4().DeltaR(gen_child_hbb[1]);
             if (mindR2>dR2 && ijet!=reco_match_to_GenB1)
@@ -1054,18 +1058,52 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
             }
           }          
 */
-          // use gen part as seed, which FatJet is matched to GenBFromHiggs1 and 2?
+
+// The following is a little bit different from the previous paragraph. 
+// This is studying still in the AK4 category, but before doing selecting the 2 highest b score jets. 
+// If we want to know that how many jets in our jet collections can be matched to the gen particles, not needed to be the selected dijet pair, can use the following code.
+// This number combines with the previous one, tells us if the step from jet collection to dijet pair reduces the gen match correctness.
+/*
+          // use gen part as seed, which jet is matched to GenBFromHiggs1 and 2?
+          int reco_match_to_GenB1=-1,reco_match_to_GenB2=-1;
+          for (int ijet=0; ijet<jets.size(); ijet++)
+          {
+            float dR1;
+            dR1 = jets[ijet].p4().DeltaR(gen_child_hbb[0]); 
+            if (mindR1>dR1)
+            {
+              mindR1 = dR1;
+              if (dR1<0.4)
+              {
+                reco_match_to_GenB1=ijet;
+                GenB1_reco_match = true;
+              }
+            }
+          }
+          for (int ijet=0; ijet<jets.size(); ijet++) //This line is used for selecting matching in all jet collections, without requiring "select 2 leading b tag score jet"
+          {
+            float dR2;
+            dR2 = jets[ijet].p4().DeltaR(gen_child_hbb[1]); 
+            if (mindR2>dR2 && ijet!=reco_match_to_GenB1)
+            {
+              mindR2 = dR2;
+              if (dR2<0.4)
+              {
+                reco_match_to_GenB2=ijet;
+                GenB2_reco_match = true;
+              }
+            }
+          }          
+*/
+
+// use gen part as seed, this line is to study if the FatJet can be matched to both gen particle GenBFromHiggs1 and 2.
 //          if (fatjets[0].p4().DeltaR(gen_child_hbb[0])<0.8 && fatjets[0].p4().DeltaR(gen_child_hbb[1])<0.8) GenB1B2_FatJet_match = true;
 
-/*          if (!GenB1B2_FatJet_match) 
-          {
-            cout<<"fatjet eta:"<<fatjets[0].p4().Eta()<<" fatjet_phi"<<fatjets[0].p4().Phi()<<endl;
-            cout<<"GenB1 eta:"<<gen_child_hbb[0].Eta()<<"GenB1 phi:"<<gen_child_hbb[0].Phi()<<"GenB2 eta:"<<gen_child_hbb[1].Eta()<<"GenB2 phi:"<<gen_child_hbb[1].Phi()<<endl;
-            cout<<"pho1 eta:"<<selectedDiPhoton.leadPho.p4().Eta()<<"reco1 phi:"<<selectedDiPhoton.leadPho.p4().Phi()<<"reco2 eta:"<<selectedDiPhoton.subleadPho.p4().Eta()<<"reco2 phi:"<<selectedDiPhoton.subleadPho.p4().Phi()<<endl;
-          }
 
-          // use reco dijet as seed, which gen jet is matched to the reco dijet pair
-          int gen_match_to_reco1=-1,gen_match_to_reco2=-1;
+// This is matched in a reverted way. To answer can the reco jet find their truth match? Instead of can the gen jet find their reco match?
+// These are in principal the same. If we require the match is an 1 to 1 matching. Which means if the reco jet can only find 1 truth match, and each truth jet can only find 1 reco match.
+// use reco dijet as seed, which gen jet is matched to the reco dijet pair
+/*          int gen_match_to_reco1=-1,gen_match_to_reco2=-1;
           float mindR1_reco=999, mindR2_reco=999;
           for (int igenjet=0; igenjet<2; igenjet++)
           {
@@ -1093,21 +1131,22 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
               }
             }
           } 
-
-          if(dijet_lead_gen_match) n_gen_matched_in_dijet++;
-          if(dijet_sublead_gen_match) n_gen_matched_in_dijet++;
-          if(GenB1_reco_match) n_gen_matched_jets++;
-          if(GenB2_reco_match) n_gen_matched_jets++;
-//          if (selectedDiJet.leadJet.p4().DeltaR(gen_child_hbb[0])<=0.4 || selectedDiJet.leadJet.p4().DeltaR(gen_child_hbb[1])<=0.4) {dijet_lead_gen_match=true; n_gen_matched_in_dijet++;}
-//          if (selectedDiJet.subleadJet.p4().DeltaR(gen_child_hbb[0])<=0.4 || selectedDiJet.subleadJet.p4().DeltaR(gen_child_hbb[1])<=0.4) {dijet_sublead_gen_match=true; n_gen_matched_in_dijet++;}
-
-//          for (int ijet=0; ijet<jets.size(); ijet++)
-//            if (jets[ijet].p4().DeltaR(gen_child_hbb[0])<=0.4 || jets[ijet].p4().DeltaR(gen_child_hbb[1])<=0.4)
-//              n_gen_matched_jets++;
 */
+
+// don't need to count those variables except doing the gen_match study
+//        if(dijet_lead_gen_match) n_gen_matched_in_dijet++;
+//        if(dijet_sublead_gen_match) n_gen_matched_in_dijet++;
+//        if(GenB1_reco_match) n_gen_matched_jets++;
+//        if(GenB2_reco_match) n_gen_matched_jets++;
+//        if (selectedDiJet.leadJet.p4().DeltaR(gen_child_hbb[0])<=0.4 || selectedDiJet.leadJet.p4().DeltaR(gen_child_hbb[1])<=0.4) {dijet_lead_gen_match=true; n_gen_matched_in_dijet++;}
+//        if (selectedDiJet.subleadJet.p4().DeltaR(gen_child_hbb[0])<=0.4 || selectedDiJet.subleadJet.p4().DeltaR(gen_child_hbb[1])<=0.4) {dijet_sublead_gen_match=true; n_gen_matched_in_dijet++;}
+
+//        for (int ijet=0; ijet<jets.size(); ijet++)
+//          if (jets[ijet].p4().DeltaR(gen_child_hbb[0])<=0.4 || jets[ijet].p4().DeltaR(gen_child_hbb[1])<=0.4)
+//            n_gen_matched_jets++;
+
         }
       }
-//      if (!GenB1_reco_match || !GenB2_reco_match) {/*cout<<GenB1_reco_match<<GenB2_reco_match<<endl;*/ continue;}
 
       // Histo filling
       h_LeadPhoton_sieie->Fill(LeadPhoton_sieie);
@@ -1120,10 +1159,11 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       h_SubleadPhoton_trkSumPtHollowConeDR03->Fill(SubleadPhoton_trkSumPtHollowConeDR03);
       h_weight->Fill(0.5, weight*factor);
       h_GenHiggs_pt_vs_GenHiggs_dR->Fill(GenHiggs_pt, GenHiggs_dR, weight*factor);
-//      cout<<selectedDiJet.leadJet.pt()<<" "<<selectedDiJet.leadJet.btagDeepFlavB()<<endl;
-//      h_lead_jet_pt_vs_jet_bscore->Fill(selectedDiJet.leadJet.pt(), selectedDiJet.leadJet.btagDeepFlavB(), weight*factor);
-//      h_sublead_jet_pt_vs_jet_bscore->Fill(selectedDiJet.subleadJet.pt(), selectedDiJet.subleadJet.btagDeepFlavB(), weight*factor);
-
+      if(!useAK8)
+      {
+        h_lead_jet_pt_vs_jet_bscore->Fill(selectedDiJet.leadJet.pt(), selectedDiJet.leadJet.btagDeepFlavB(), weight*factor);
+        h_sublead_jet_pt_vs_jet_bscore->Fill(selectedDiJet.subleadJet.pt(), selectedDiJet.subleadJet.btagDeepFlavB(), weight*factor);
+      }
       tout->Fill();
     } // Event loop
     delete file;

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -749,7 +749,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       TLorentzVector x_cand;
       if (useAK8== true) x_cand = selectedDiPhoton.p4 + fatjets[0].p4();
 
-// if (!useAK8) continue;
+      if (!useAK8 && nt.nJet()==0) continue; 
 
       Jet leadJet, subleadJet;
       Jets jets;
@@ -765,7 +765,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
         subleadJet = selectedDiJet.subleadJet;
       }
       DiJet selectedDiJet = DiJet(leadJet, subleadJet);
-      
+
       if (isMC) 
       {
         // Apply electron veto SF

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -723,7 +723,6 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
 //      if (isMC) jets = getJets(selectedPhotons, JESUnc, JERUnc);
 //      else jets = getJets(selectedPhotons, 0, 0);
 //      if (jets.size() < 2) continue; 
-cout<<1<<endl;
       if (!useAK8)
       {
       Jets jets;
@@ -856,7 +855,6 @@ cout<<1<<endl;
 
       // Setting output variables
       x_cand = selectedDiPhoton.p4 + selectedDiJet.p4;
-cout<<2<<endl;
         n_jets = jets.size();
         dijet_lead_pt = selectedDiJet.leadJet.pt();
         dijet_lead_eta = selectedDiJet.leadJet.eta();
@@ -876,7 +874,6 @@ cout<<2<<endl;
       }
       else
       {
-cout<<3<<endl;
         dijet_pt = fatjets[0].p4().Pt();
         dijet_eta = fatjets[0].p4().Eta();
         dijet_phi = fatjets[0].p4().Phi();

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -382,6 +382,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
   bool GenB1_reco_match, GenB2_reco_match;
   bool GenB1B2_FatJet_match;
   bool dijet_lead_gen_match, dijet_sublead_gen_match;
+  bool useAK8;
   float mindR1, mindR2, mindR1_reco, mindR2_reco;
   float GenHiggs_pt, GenHiggs_eta, GenHiggs_phi, GenHiggs_mass, GenHiggs_dR;
   float GenY_pt, GenY_eta, GenY_phi, GenY_mass, GenY_dR;
@@ -425,6 +426,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
   tout->Branch("Diphoton_pt_mgg",&Diphoton_pt_mgg,"Diphoton_pt_mgg/F");
   tout->Branch("Diphoton_dR",&Diphoton_dR,"Diphoton_dR/F");
 
+  tout->Branch("useAK8",&useAK8,"useAK8/B");
   tout->Branch("n_jets",&n_jets,"n_jets/I");  
   tout->Branch("n_Genjets",&n_Genjets,"n_Genjets/I");  
   tout->Branch("dijet_lead_pt",&dijet_lead_pt,"dijet_lead_pt/F");
@@ -572,6 +574,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       SubleadPhoton_sieie=-999, SubleadPhoton_pfPhoIso03=-999, SubleadPhoton_chargedHadronIso=-999, SubleadPhoton_r9=-999, SubleadPhoton_trkSumPtHollowConeDR03=-999;
       LeadPhoton_pixelSeed=true, SubleadPhoton_pixelSeed=true;
 
+      useAK8=1;
       n_jets=-1;
       n_Genjets=-1;
       dijet_lead_pt=-999, dijet_lead_eta=-999, dijet_lead_phi=-999, dijet_lead_mass=-999, dijet_lead_btagDeepFlavB=-999;
@@ -706,7 +709,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       GenJets Genjets;
       if (isMC) Genjets = getGenJets();
       FatJets fatjets;
-      bool useAK8=true,useAK4=false;
+      useAK8=true;
       if (nt.nFatJet()==0) 
       {
         useAK8=false;
@@ -719,10 +722,6 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       
       TLorentzVector x_cand;
       if (useAK8== true) x_cand = selectedDiPhoton.p4 + fatjets[0].p4();
-//      Jets jets;
-//      if (isMC) jets = getJets(selectedPhotons, JESUnc, JERUnc);
-//      else jets = getJets(selectedPhotons, 0, 0);
-//      if (jets.size() < 2) continue; 
       if (!useAK8)
       {
       Jets jets;

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -723,17 +723,21 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       TLorentzVector x_cand;
       if (useAK8== true) x_cand = selectedDiPhoton.p4 + fatjets[0].p4();
 
+      Jet leadJet, subleadJet;
+      Jets jets;
       if (!useAK8) // if don't use AK8 and also does not have 2 qualified jets, continue
       {
-        Jets jets;
         if (isMC) jets = getJets(selectedPhotons, JESUnc, JERUnc);
         else jets = getJets(selectedPhotons, 0, 0);
         if (jets.size() < 2) continue; 
         DiJets dijets = DiJetPreselection(jets);
         DiJet selectedDiJet = dijets[0];
         if (dijets[0].p4.M()<50) continue;
+        leadJet = selectedDiJet.leadJet;
+        subleadJet = selectedDiJet.subleadJet;
       }
-
+      DiJet selectedDiJet = DiJet(leadJet, subleadJet);
+      
       if (isMC) 
       {
         // Apply electron veto SF

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -722,16 +722,20 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       
       TLorentzVector x_cand;
       if (useAK8== true) x_cand = selectedDiPhoton.p4 + fatjets[0].p4();
-      if (!useAK8)
+
+      if (!useAK8) // if don't use AK8 and also does not have 2 qualified jets, continue
       {
-      Jets jets;
-      if (isMC) jets = getJets(selectedPhotons, JESUnc, JERUnc);
-      else jets = getJets(selectedPhotons, 0, 0);
-      if (jets.size() < 2) continue; 
+        Jets jets;
+        if (isMC) jets = getJets(selectedPhotons, JESUnc, JERUnc);
+        else jets = getJets(selectedPhotons, 0, 0);
+        if (jets.size() < 2) continue; 
         DiJets dijets = DiJetPreselection(jets);
         DiJet selectedDiJet = dijets[0];
         if (dijets[0].p4.M()<50) continue;
-      if (isMC) {
+      }
+
+      if (isMC) 
+      {
         // Apply electron veto SF
         if ( electronVetoSF!=0 ) {
           if ( electronVetoSF==1  ) weight *= electronVetoSF::get_electronVetoSF(selectedDiPhoton.leadPho.eta(), selectedDiPhoton.leadPho.r9(), year, "central")*electronVetoSF::get_electronVetoSF(selectedDiPhoton.subleadPho.eta(), selectedDiPhoton.subleadPho.r9(), year, "central");
@@ -765,95 +769,100 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
           if ( phoMVAIDWP90SF==-2 ) weight *= phoMVAIDWP90SF::get_phoMVAIDWP90SF(selectedDiPhoton.leadPho.pt(), selectedDiPhoton.leadPho.eta(), year, "down")*phoMVAIDWP90SF::get_phoMVAIDWP90SF(selectedDiPhoton.subleadPho.pt(), selectedDiPhoton.subleadPho.eta(), year, "down");
         }
 
-        // Apply bTagSF and get the weights before and after the application to normalize post-preselection
-        if ( bTagSF!=0 ) {
-          float leadJetBTagSF, subleadJetBTagSF;
-          if ( bTagSF==1 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape();
+        if (!useAK8)
+        {
+          // Apply bTagSF and get the weights before and after the application to normalize post-preselection
+          if ( bTagSF!=0 ) {
+            float leadJetBTagSF, subleadJetBTagSF;
+            if ( bTagSF==1 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape();
+            }
+            if ( bTagSF==2 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hf();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hf();
+            }
+            if ( bTagSF==-2 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hf();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hf();
+            }
+            if ( bTagSF==3 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hfstats1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hfstats1();
+            }
+            if ( bTagSF==-3 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hfstats1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hfstats1();
+            }
+            if ( bTagSF==4 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hfstats2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hfstats2();
+            }
+            if ( bTagSF==-4 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hfstats2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hfstats2();
+            }
+            if ( bTagSF==5 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lf();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lf();
+            }
+            if ( bTagSF==-5 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lf();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lf();
+            }
+            if ( bTagSF==6 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lfstats1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lfstats1();
+            }
+            if ( bTagSF==-6 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lfstats1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lfstats1();
+            }
+            if ( bTagSF==7 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lfstats2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lfstats2();
+            }
+            if ( bTagSF==-7 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lfstats2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lfstats2();
+            }
+            if ( bTagSF==8 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_jes();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_jes();
+            }
+            if ( bTagSF==-8 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_jes();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_jes();
+            }
+            if ( bTagSF==9 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_cferr1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_cferr1();
+            }
+            if ( bTagSF==-9 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_cferr1();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_cferr1();
+            }
+            if ( bTagSF==10 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_cferr2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_cferr2();
+            }
+            if ( bTagSF==-10 ) {
+              leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_cferr2();
+              subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_cferr2();
+            }
+            weight_beforeBTagSF = weight;
+            h_weight_beforeBTagSF->Fill(0.5, weight);
+            weight *= leadJetBTagSF * subleadJetBTagSF;
+            weight_afterBTagSF = weight;
+            h_weight_afterBTagSF->Fill(0.5, weight);
           }
-          if ( bTagSF==2 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hf();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hf();
-          }
-          if ( bTagSF==-2 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hf();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hf();
-          }
-          if ( bTagSF==3 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hfstats1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hfstats1();
-          }
-          if ( bTagSF==-3 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hfstats1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hfstats1();
-          }
-          if ( bTagSF==4 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_hfstats2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_hfstats2();
-          }
-          if ( bTagSF==-4 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_hfstats2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_hfstats2();
-          }
-          if ( bTagSF==5 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lf();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lf();
-          }
-          if ( bTagSF==-5 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lf();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lf();
-          }
-          if ( bTagSF==6 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lfstats1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lfstats1();
-          }
-          if ( bTagSF==-6 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lfstats1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lfstats1();
-          }
-          if ( bTagSF==7 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_lfstats2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_lfstats2();
-          }
-          if ( bTagSF==-7 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_lfstats2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_lfstats2();
-          }
-          if ( bTagSF==8 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_jes();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_jes();
-          }
-          if ( bTagSF==-8 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_jes();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_jes();
-          }
-          if ( bTagSF==9 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_cferr1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_cferr1();
-          }
-          if ( bTagSF==-9 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_cferr1();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_cferr1();
-          }
-          if ( bTagSF==10 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_up_cferr2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_up_cferr2();
-          }
-          if ( bTagSF==-10 ) {
-            leadJetBTagSF = selectedDiJet.leadJet.btagSF_deepjet_shape_down_cferr2();
-            subleadJetBTagSF = selectedDiJet.subleadJet.btagSF_deepjet_shape_down_cferr2();
-          }
-          weight_beforeBTagSF = weight;
-          h_weight_beforeBTagSF->Fill(0.5, weight);
-          weight *= leadJetBTagSF * subleadJetBTagSF;
-          weight_afterBTagSF = weight;
-          h_weight_afterBTagSF->Fill(0.5, weight);
         }
       }
 
       // Setting output variables
-      x_cand = selectedDiPhoton.p4 + selectedDiJet.p4;
+      if (!useAK8) // if not use AK8, all the variables are built using the 2 jets
+      {
+        x_cand = selectedDiPhoton.p4 + selectedDiJet.p4;
         n_jets = jets.size();
         dijet_lead_pt = selectedDiJet.leadJet.pt();
         dijet_lead_eta = selectedDiJet.leadJet.eta();

--- a/cpp/ScanChain_Hgg.C
+++ b/cpp/ScanChain_Hgg.C
@@ -368,7 +368,11 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
   bool LeadPhoton_pixelSeed, SubleadPhoton_pixelSeed;
 
   int n_jets, n_Genjets;
+  int n_subjet_in_fatjet;
   float dijet_lead_pt, dijet_lead_eta, dijet_lead_phi, dijet_lead_mass, dijet_lead_btagDeepFlavB;
+  float subjet_lead_pt, subjet_lead_eta, subjet_lead_phi, subjet_lead_mass, subjet1_bscore;
+  float subjet_sublead_pt, subjet_sublead_eta, subjet_sublead_phi, subjet_sublead_mass, subjet2_bscore;
+  float fatjet_pt, fatjet_eta, fatjet_mass, fatjet_phi;
   float fatjet_Hbb_score;
   float dijet_sublead_pt, dijet_sublead_eta, dijet_sublead_phi, dijet_sublead_mass, dijet_sublead_btagDeepFlavB;
   float dijet_pt, dijet_eta, dijet_phi, dijet_mass, dijet_dR;
@@ -428,6 +432,7 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
 
   tout->Branch("useAK8",&useAK8,"useAK8/B");
   tout->Branch("n_jets",&n_jets,"n_jets/I");  
+  tout->Branch("n_subjet_in_fatjet",&n_subjet_in_fatjet,"n_subjet_in_fatjet/I");  
   tout->Branch("n_Genjets",&n_Genjets,"n_Genjets/I");  
   tout->Branch("dijet_lead_pt",&dijet_lead_pt,"dijet_lead_pt/F");
   tout->Branch("dijet_lead_eta",&dijet_lead_eta,"dijet_lead_eta/F");
@@ -435,11 +440,28 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
   tout->Branch("dijet_lead_mass",&dijet_lead_mass,"dijet_lead_mass/F");
   tout->Branch("dijet_lead_btagDeepFlavB",&dijet_lead_btagDeepFlavB,"dijet_lead_btagDeepFlavB/F"); 
 
+  tout->Branch("subjet_lead_pt",&subjet_lead_pt,"subjet_lead_pt/F");
+  tout->Branch("subjet_lead_eta",&subjet_lead_eta,"subjet_lead_eta/F");
+  tout->Branch("subjet_lead_phi",&subjet_lead_phi,"subjet_lead_phi/F");
+  tout->Branch("subjet_lead_mass",&subjet_lead_mass,"subjet_lead_mass/F");
+  tout->Branch("subjet1_bscore", &subjet1_bscore, "subjet1_bscore/F");
+
+  tout->Branch("fatjet_pt",&fatjet_pt,"fatjet_pt/F");
+  tout->Branch("fatjet_eta",&fatjet_eta,"fatjet_eta/F");
+  tout->Branch("fatjet_phi",&fatjet_phi,"fatjet_phi/F");
+  tout->Branch("fatjet_mass",&fatjet_mass,"fatjet_mass/F");
+
   tout->Branch("dijet_sublead_pt",&dijet_sublead_pt,"dijet_sublead_pt/F");
   tout->Branch("dijet_sublead_eta",&dijet_sublead_eta,"dijet_sublead_eta/F");
   tout->Branch("dijet_sublead_phi",&dijet_sublead_phi,"dijet_sublead_phi/F");
   tout->Branch("dijet_sublead_mass",&dijet_sublead_mass,"dijet_sublead_mass/F");
   tout->Branch("dijet_sublead_btagDeepFlavB",&dijet_sublead_btagDeepFlavB,"dijet_sublead_btagDeepFlavB/F");
+
+  tout->Branch("subjet_sublead_pt",&subjet_sublead_pt,"subjet_sublead_pt/F");
+  tout->Branch("subjet_sublead_eta",&subjet_sublead_eta,"subjet_sublead_eta/F");
+  tout->Branch("subjet_sublead_phi",&subjet_sublead_phi,"subjet_sublead_phi/F");
+  tout->Branch("subjet_sublead_mass",&subjet_sublead_mass,"subjet_sublead_mass/F");
+  tout->Branch("subjet2_bscore", &subjet2_bscore, "subjet2_bscore/F");
 
   tout->Branch("dijet_pt",&dijet_pt,"dijet_pt/F");
   tout->Branch("dijet_eta",&dijet_eta,"dijet_eta/F");  
@@ -575,11 +597,15 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       LeadPhoton_pixelSeed=true, SubleadPhoton_pixelSeed=true;
 
       useAK8=1;
-      n_jets=-1;
-      n_Genjets=-1;
+      n_jets=0;
+      n_subjet_in_fatjet=0;
+      n_Genjets=0;
       dijet_lead_pt=-999, dijet_lead_eta=-999, dijet_lead_phi=-999, dijet_lead_mass=-999, dijet_lead_btagDeepFlavB=-999;
+      subjet_lead_pt=-999, subjet_lead_eta=-999, subjet_lead_phi=-999, subjet_lead_mass=-999, subjet1_bscore=-999;
+      fatjet_pt=-999, fatjet_eta=-999, fatjet_phi=-999, fatjet_mass=-999,
       fatjet_Hbb_score=-999;
       dijet_sublead_pt=-999, dijet_sublead_eta=-999, dijet_sublead_phi=-999, dijet_sublead_mass=-999, dijet_sublead_btagDeepFlavB=-999;
+      subjet_sublead_pt=-999, subjet_sublead_eta=-999, subjet_sublead_phi=-999, subjet_sublead_mass=-999, subjet2_bscore=-999;
       dijet_pt=-999, dijet_eta=-999, dijet_phi=-999, dijet_mass=-999, dijet_dR=-999;
       pfmet_pt=-999, puppimet_pt=-999;
       eventNum=0;
@@ -722,6 +748,8 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       
       TLorentzVector x_cand;
       if (useAK8== true) x_cand = selectedDiPhoton.p4 + fatjets[0].p4();
+
+// if (!useAK8) continue;
 
       Jet leadJet, subleadJet;
       Jets jets;
@@ -886,11 +914,24 @@ int ScanChain_Hgg(TChain *ch, double genEventSumw, TString year, TString process
       }
       else
       {
-        dijet_pt = fatjets[0].p4().Pt();
-        dijet_eta = fatjets[0].p4().Eta();
-        dijet_phi = fatjets[0].p4().Phi();
-        dijet_mass = fatjets[0].p4().M();
+        fatjet_pt = fatjets[0].p4().Pt();
+        fatjet_eta = fatjets[0].p4().Eta();
+        fatjet_phi = fatjets[0].p4().Phi();
+        fatjet_mass = fatjets[0].p4().M();
         fatjet_Hbb_score = fatjets[0].Hbb_score();
+
+      if (fatjets[0].subJetIdx1()!=-1) n_subjet_in_fatjet++;
+      if (fatjets[0].subJetIdx2()!=-1) n_subjet_in_fatjet++;
+      subjet_lead_pt = fatjets[0].SubJet1_p4().Pt();
+      subjet_lead_eta = fatjets[0].SubJet1_p4().Eta();
+      subjet_lead_phi = fatjets[0].SubJet1_p4().Phi();
+      subjet_lead_mass = fatjets[0].SubJet1_p4().M();
+      subjet1_bscore = fatjets[0].subjet1_bscore();
+      subjet_sublead_pt = fatjets[0].SubJet2_p4().Pt();
+      subjet_sublead_eta = fatjets[0].SubJet2_p4().Eta();
+      subjet_sublead_phi = fatjets[0].SubJet2_p4().Phi();
+      subjet_sublead_mass = fatjets[0].SubJet2_p4().M();
+      subjet2_bscore = fatjets[0].subjet2_bscore();
       }
 
       xcand_pt = x_cand.Pt();


### PR DESCRIPTION
This is a study about the jet reconstruction quality, if our jet selections can pick up the correct jet matched to the gen particle or not. Prioritize the AK8 jets and if we can't find any AK8 jets in the event, choose 2 AK4 jets. 
The gen matching parts are commented out by default. To save time, this part only needs to be run for doing this specific study and does not need to be run every time in the analysis. One can reproduce the results on gen study by using those codes.